### PR TITLE
Address fix for attiny example sketch

### DIFF
--- a/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
+++ b/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
@@ -68,8 +68,8 @@ void setup() {
   radio.begin(); // Start up the radio
   radio.setAutoAck(1); // Ensure autoACK is enabled
   radio.setRetries(15,15); // Max delay between retries & number of retries
-  radio.openWritingPipe(addresses[0]); // Write to device address '1Node'
-  radio.openReadingPipe(1,addresses[1]); // Read on pipe 1 for device address '2Node'
+  radio.openWritingPipe(addresses[1]); // Write to device address '2Node'
+  radio.openReadingPipe(1,addresses[0]); // Read on pipe 1 for device address '1Node'
   radio.startListening(); // Start listening
 }
 


### PR DESCRIPTION
The addresses are reversed when using with the GettingStarted sketch as
described in the comments. This causes the arduino and the tiny to both
be in receiver mode.