### PR TITLE
Added initial MRAA support

### DIFF
--- a/RF24.h
+++ b/RF24.h
@@ -69,7 +69,12 @@ private:
   uint16_t spi_speed; /**< SPI Bus Speed */
   uint8_t spi_rxbuff[32+1] ; //SPI receive buffer (payload max 32 bytes)
   uint8_t spi_txbuff[32+1] ; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
-#endif  
+#elif defined(MRAA)
+  mraa_spi_context m_spi;
+  mraa_gpio_context m_csnPinCtx;
+  mraa_gpio_context m_cePinCtx;
+#endif
+
   bool p_variant; /* False for RF24L01 and true for RF24L01P */
   uint8_t payload_size; /**< Fixed size of payloads */
   bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */
@@ -111,6 +116,13 @@ public:
   
   RF24(uint8_t _cepin, uint8_t _cspin, uint32_t spispeed );
   //#endif
+
+  /**
+   * Default destructor
+   * Removes allocated contexts with MRAA
+   */
+  ~RF24();
+
   /**
    * Begin operation of the chip
    * 

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -51,7 +51,10 @@
   
   #include "arch/LittleWire/RF24_arch_config.h"
 
+// MRAA
+#elif defined(MRAA)
   
+  #include "arch/mraa/RF24_arch_config.h"
   
 //Everything else
 #else 

--- a/arch/mraa/RF24_arch_config.h
+++ b/arch/mraa/RF24_arch_config.h
@@ -1,0 +1,39 @@
+#ifndef __ARCH_CONFIG_H__
+#define __ARCH_CONFIG_H__
+
+  #include <stdint.h>
+  #include <stdio.h>
+  #include <time.h>
+  #include <string.h>
+  #include <sys/time.h>
+  #include <stddef.h>
+  #include <iostream>
+  #include <unistd.h>
+  #include <stdlib.h>
+  #include <mraa/gpio.h>
+  #include <mraa/spi.h>
+
+  #include <UtilTime.h> // Precompiled arduino x86 based utiltime for timing functions
+
+  // GCC a Arduino Missing
+  #define HIGH	1
+  #define LOW	0
+  #define _BV(x) (1<<(x))
+  #define pgm_read_word(p) (*(p))
+  #define pgm_read_byte(p) (*(p))
+  
+  //typedef uint16_t prog_uint16_t;
+  #define PSTR(x) (x)
+  #define printf_P printf
+  #define strlen_P strlen
+  #define PROGMEM
+  #define PRIPSTR "%s"
+
+  #ifdef SERIAL_DEBUG
+	#define IF_SERIAL_DEBUG(x) ({x;})
+  #else
+	#define IF_SERIAL_DEBUG(x)
+  #endif
+  
+  
+#endif


### PR DESCRIPTION
Hi!
With new arch model you've added into RF24, I've added library support based on top of MRAA hardware abstraction layer I'm using for my Galileo board. It's currently checked with ping-pong test at my side. AFAIK MRAA is having many other platforms supported like BBB, Raspberry Pi and so on, so it could be worth looking at to add a hardware abstraction layer where possible.

Main drawbacks I currently have: you should define MRAA symbol in compiler options, and you need to have arduino x86 UtilTime.cpp as static lib to support delay, delaymicroseconds, millis and micros functions. It is shame for me, but I haven't located them in standard linux libs, but I can add support file to commit, if needed.

There is also a problem with compiling RF24Network ontop of new arch style, I'll be posting an issue on it in RF24Network repo.