### PR TITLE
Fixed issue with ARDUINO not issuing CS for radio

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -24,8 +24,9 @@ void RF24::csn(bool mode)
   			_SPI.setDataMode(SPI_MODE0);
 			_SPI.setClockDivider(SPI_CLOCK_DIV2);
 	#endif
+#endif
 
-#elif defined (RF24_RPi)
+#if defined (RF24_RPi)
     if(!mode){
 
 	  _SPI.setBitOrder(BCM2835_SPI_BIT_ORDER_MSBFIRST);


### PR DESCRIPTION
Found an issue regarding CSN pin with new MRAA commit: https://github.com/TMRh20/RF24/commit/3d049abfe890225bb8232f2a025e7415e731e6e2

in ```RF24::csn(bool mode)``` ```#ifdef ARDUINO``` block is now not closed with ```#endif``` so that ```#elif !defined (ARDUINO_SAM_DUE)``` never get's compiled, and actual digitalWrite is issued.

This works with MRAA builds, because ```ARDUINO``` is not defined there. Feeling myself useless, as I spent half a day with scope trying to figure out what's happened to my galileo, while problem was on the other side :)

Also, shouldn't ```SPI::setBitDataOrder``` and other SPI related functions (except for ```chipSelect``` for RPi perhaps) be issued in ```RF24::begin```?