### PR TITLE
MRAA: Updated memory usage

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -14,26 +14,26 @@
 
 void RF24::csn(bool mode)
 {
-  // Minimum ideal SPI bus speed is 2x data rate
-  // If we assume 2Mbs data rate and 16Mhz clock, a
-  // divider of 4 is the minimum we want.
-  // CLK:BUS 8Mhz:2Mhz, 16Mhz:4Mhz, or 20Mhz:5Mhz
-#ifdef ARDUINO
+	// Minimum ideal SPI bus speed is 2x data rate
+	// If we assume 2Mbs data rate and 16Mhz clock, a
+	// divider of 4 is the minimum we want.
+	// CLK:BUS 8Mhz:2Mhz, 16Mhz:4Mhz, or 20Mhz:5Mhz
+#if defined(ARDUINO)
 	#if  ( !defined(RF24_TINY) && !defined (__arm__)  && !defined (SOFTSPI)) || defined (CORE_TEENSY)
- 			_SPI.setBitOrder(MSBFIRST);
-  			_SPI.setDataMode(SPI_MODE0);
-			_SPI.setClockDivider(SPI_CLOCK_DIV2);
+		_SPI.setBitOrder(MSBFIRST);
+		_SPI.setDataMode(SPI_MODE0);
+		_SPI.setClockDivider(SPI_CLOCK_DIV2);
 	#endif
 #endif
 
 #if defined (RF24_RPi)
-    if(!mode){
+	if(!mode){
 
-	  _SPI.setBitOrder(BCM2835_SPI_BIT_ORDER_MSBFIRST);
-	  _SPI.setDataMode(BCM2835_SPI_MODE0);
-	  _SPI.setClockDivider(spi_speed);
-      _SPI.chipSelect(csn_pin);
-      delayMicroseconds(5);
+		_SPI.setBitOrder(BCM2835_SPI_BIT_ORDER_MSBFIRST);
+		_SPI.setDataMode(BCM2835_SPI_MODE0);
+		_SPI.setClockDivider(spi_speed);
+		_SPI.chipSelect(csn_pin);
+		delayMicroseconds(5);
 	}
 #elif defined (RF24_TINY)
 	if (ce_pin != csn_pin) {
@@ -52,7 +52,7 @@ void RF24::csn(bool mode)
 #elif !defined (ARDUINO_SAM_DUE)
 	digitalWrite(csn_pin,mode);
 	#if !defined (RF24_BBB)
-    delayMicroseconds(5);
+		delayMicroseconds(5);
 	#endif
 #endif
 

--- a/RF24.h
+++ b/RF24.h
@@ -114,6 +114,9 @@ public:
   
   RF24(uint8_t _cepin, uint8_t _cspin, uint32_t spispeed );
   //#endif
+
+  virtual ~RF24() {};
+
   /**
    * Begin operation of the chip
    * 

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -28,10 +28,10 @@
 
 	
 //Generic Linux/ARM and //http://iotdk.intel.com/docs/master/mraa/
-#if ( defined (__linux) || defined (LINUX) ) && defined( __arm__ ) || defined MRAA // BeagleBone Black running GNU/Linux or any other ARM-based linux device
+#if ( defined (__linux) || defined (LINUX) ) && defined( __arm__ ) || defined(RF24_MRAA) // BeagleBone Black running GNU/Linux or any other ARM-based linux device
 
   // The Makefile checks for bcm2835 (RPi) and copies the correct includes.h file to /arch/includes.h (Default is spidev config)
-  // This behaviour can be overridden by calling 'make RF24_SPIDEV=1' or 'make RF24_MRAA=1'
+  // This behavior can be overridden by calling 'make RF24_SPIDEV=1' or 'make RF24_MRAA=1'
   // The includes.h file defines either RF24_RPi, MRAA or RF24_BBB and includes the correct RF24_arch_config.h file
   #include "arch/includes.h"
 

--- a/arch/MRAA/RF24_arch_config.h
+++ b/arch/MRAA/RF24_arch_config.h
@@ -4,7 +4,8 @@
   #include "mraa.h"
   #include "spi.h"
   #include "gpio.h"
-  #include "compatibility.h"
+  //#include "compatibility.h"
+  #include <UtilTime.h>
   #include <stdint.h>
   #include <stdio.h>
   #include <time.h>
@@ -30,6 +31,7 @@
   //typedef uint16_t prog_uint16_t;
   #define PSTR(x) (x)
   #define printf_P printf
+  #define sprintf_P sprintf
   #define strlen_P strlen
   #define PROGMEM
   #define PRIPSTR "%s"
@@ -44,9 +46,9 @@
   #define digitalWrite(pin, value) gpio.write(pin, value)
   #define digitalRead(pin) GPIO::read(pin)
   #define pinMode(pin, direction) gpio.open(pin, direction)
-  #define delay(milisec) __msleep(milisec)
-  #define delayMicroseconds(usec) __usleep(usec)
-  #define millis() __millis()
+  //#define delay(milisec) __msleep(milisec)
+  //#define delayMicroseconds(usec) __usleep(usec)
+  //#define millis() __millis()
   
   #define INPUT mraa::DIR_IN
   #define OUTPUT mraa::DIR_OUT  

--- a/arch/MRAA/RF24_arch_config.h
+++ b/arch/MRAA/RF24_arch_config.h
@@ -4,8 +4,8 @@
   #include "mraa.h"
   #include "spi.h"
   #include "gpio.h"
-  //#include "compatibility.h"
-  #include <UtilTime.h>
+  #include "compatibility.h"
+
   #include <stdint.h>
   #include <stdio.h>
   #include <time.h>
@@ -16,7 +16,7 @@
   #include <unistd.h>
   #include <stdlib.h>
   
- // #include <UtilTime.h> // Precompiled arduino x86 based utiltime for timing functions
+  //#include <UtilTime.h> // Precompiled arduino x86 based utiltime for timing functions
 
   // GCC a Arduino Missing
   #define HIGH	1
@@ -42,15 +42,23 @@
 	#define IF_SERIAL_DEBUG(x)
   #endif
   
-  //#define digitalWrite(pin, value) mraa_gpio_write((mraa_gpio_context)pin, value)
   #define digitalWrite(pin, value) gpio.write(pin, value)
   #define digitalRead(pin) GPIO::read(pin)
   #define pinMode(pin, direction) gpio.open(pin, direction)
-  //#define delay(milisec) __msleep(milisec)
-  //#define delayMicroseconds(usec) __usleep(usec)
-  //#define millis() __millis()
+
+  #ifndef __TIME_H__
+    // Prophet: Redefine time functions only if precompiled arduino time is not included
+	#define delay(milisec) __msleep(milisec)
+	#define delayMicroseconds(usec) __usleep(usec)
+	#define millis() __millis()
+  #endif
   
   #define INPUT mraa::DIR_IN
   #define OUTPUT mraa::DIR_OUT  
+
+  // SPI defines for ARDUINO API
+  #define MSBFIRST 1
+  #define SPI_MODE0 mraa::SPI_MODE0
+  #define SPI_CLOCK_DIV2 8000000
 
 #endif

--- a/arch/MRAA/compatibility.c
+++ b/arch/MRAA/compatibility.c
@@ -1,5 +1,9 @@
 
 #include "compatibility.h"
+
+static struct timeval start, end;
+//static long mtime, seconds, useconds;
+
 /**********************************************************************/
 /**
  * This function is added in order to simulate arduino delay() function

--- a/arch/MRAA/compatibility.h
+++ b/arch/MRAA/compatibility.h
@@ -16,9 +16,6 @@ extern "C" {
 #include <unistd.h>
 #include <sys/time.h>
 
-static struct timeval start, end;
-//static long mtime, seconds, useconds;    
-
 void __msleep(int milisec);
 void __usleep(int milisec);
 void __start_timer();

--- a/arch/MRAA/gpio.cpp
+++ b/arch/MRAA/gpio.cpp
@@ -6,9 +6,17 @@
 #include "gpio.h"
 
 GPIO::GPIO() {
+	// Prophet: basic members initialization
+	gpio_ce_pin = -1;
+	gpio_cs_pin = -1;
+	gpio_0 = NULL;
+	gpio_1 = NULL;
 }
 
 GPIO::~GPIO() {
+	// Prophet: this should free memory, and unexport pins when RF24 and/or GPIO gets deleted or goes out of scope
+	this->close(gpio_ce_pin);
+	this->close(gpio_cs_pin);
 }
 
 void GPIO::begin(uint8_t ce_pin, uint8_t cs_pin)
@@ -16,9 +24,10 @@ void GPIO::begin(uint8_t ce_pin, uint8_t cs_pin)
 	gpio_ce_pin = ce_pin;
 	gpio_cs_pin = cs_pin;
 	
-	gpio_0 = new mraa::Gpio(ce_pin,0);
-	gpio_1 = new mraa::Gpio(cs_pin,0);
-	
+	// Prophet: owner can be set here, because we use our pins exclusively, and are making mraa:Gpio context persistent
+	// so pins will be unexported only if close is called, or on destruction
+	gpio_0 = new mraa::Gpio(ce_pin/*,0*/);
+	gpio_1 = new mraa::Gpio(cs_pin/*,0*/);
 }
 void GPIO::open(int port, int DDR)
 {		
@@ -36,8 +45,20 @@ void GPIO::open(int port, int DDR)
 
 void GPIO::close(int port)
 {	
-	delete gpio_0;
-	delete gpio_1;
+	// Prophet: using same theme of working with port numbers as with GPIO::open,
+	// checking for mraa::Gpio context existence to be sure, that GPIO::begin was called
+	if(port == gpio_ce_pin)
+	{
+		if (gpio_0 != NULL)	{
+			delete gpio_0;
+		}
+	}
+
+	if(port == gpio_cs_pin) {
+		if (gpio_1 != NULL)	{
+			delete gpio_1;
+		}
+	}
 }
 
 int GPIO::read(int port)

--- a/arch/MRAA/gpio.h
+++ b/arch/MRAA/gpio.h
@@ -3,8 +3,8 @@
  * 
  */
 
-#ifndef H
-#define	H
+#ifndef RF24_ARCH_GPIO_H
+#define	RF24_ARCH_GPIO_H
 
 #include <cstdio>
 #include <stdio.h>
@@ -16,7 +16,8 @@ public:
 
 	/* Constants */
 		
-	GPIO();		
+	GPIO();
+	virtual ~GPIO();
 	
 	/**
 	 * Sets up GPIO on the CE & CS pins
@@ -48,9 +49,7 @@ public:
 	* @param value
 	*/	
 	void write(int port,int value);	
-	
-	virtual ~GPIO();
-	
+
 private:
 	int gpio_ce_pin; /** ce_pin value of the RF24 device **/
 	int gpio_cs_pin; /** cs_pin value of the RF24 device **/
@@ -58,5 +57,5 @@ private:
 	mraa::Gpio* gpio_1; /** gpio object for cs_pin **/
 };
 
-#endif	/* H */
+#endif	/* RF24_ARCH_GPIO_H */
 

--- a/arch/MRAA/includes.h
+++ b/arch/MRAA/includes.h
@@ -3,7 +3,7 @@
 #define __RF24_INCLUDES_H__
 
   #ifndef MRAA
-  #define MRAA
+  	  #define MRAA
   #endif
   #include "MRAA/RF24_arch_config.h"
    

--- a/arch/MRAA/spi.cpp
+++ b/arch/MRAA/spi.cpp
@@ -1,6 +1,7 @@
 
 
 #include "spi.h"
+#include "mraa.h"
 
 SPI::SPI() {
 	mspi = NULL;
@@ -8,21 +9,15 @@ SPI::SPI() {
 
 
 void SPI::begin(void) {
+	// Prophet: this is only a suggestion, but can update begin with SPI bus number for devices with multiple SPI ports,
+	// and then #define _SPI_BUS_NUMBER in config, so for non MRAA platforms it will state as SPI.beign(),
+	// while for MRAA ones it will go SPI.begin(0) or any other valid bus number
 
 	mspi = new mraa::Spi(0);
 
 	mspi->mode(mraa::SPI_MODE0);
 	mspi->bitPerWord(8);
-	mspi->frequency(4000000);
-}
-
-// Prophet: this is only a suggestion, but can be useful for devices with multiple SPI ports
-void SPI::begin(int bus, int frequency) {
-	mspi = new mraa::Spi(bus);
-
-	mspi->mode(mraa::SPI_MODE0);
-	mspi->bitPerWord(8);
-	mspi->frequency(frequency);
+	mspi->frequency(8000000); // Prophet: this will try to set 8MHz, however MRAA will reset to max platform speed and syslog a message of it
 }
 
 void SPI::end() {
@@ -32,15 +27,18 @@ void SPI::end() {
 }
 
 void SPI::setBitOrder(uint8_t bit_order) {
-	mspi->bitPerWord(bit_order);
+	if (mspi != NULL)
+		mspi->lsbmode((mraa_boolean_t)bit_order); // Prophet: bit_order
 }
 
 void SPI::setDataMode(uint8_t data_mode) {
-	mspi->mode((mraa::Spi_Mode)data_mode);
+	if (mspi != NULL)
+		mspi->mode((mraa::Spi_Mode)data_mode);
 }
 
 void SPI::setClockDivider(uint32_t spi_speed) {
-	mspi->frequency(spi_speed);
+	if (mspi != NULL)
+		mspi->frequency(spi_speed);
 }
 
 void SPI::chipSelect(int csn_pin){

--- a/arch/MRAA/spi.cpp
+++ b/arch/MRAA/spi.cpp
@@ -3,21 +3,32 @@
 #include "spi.h"
 
 SPI::SPI() {
-
+	mspi = NULL;
 }
 
 
-void SPI::begin( ) {	
+void SPI::begin(void) {
 
 	mspi = new mraa::Spi(0);
 
 	mspi->mode(mraa::SPI_MODE0);
 	mspi->bitPerWord(8);
-	mspi->frequency(8000000);
+	mspi->frequency(4000000);
+}
+
+// Prophet: this is only a suggestion, but can be useful for devices with multiple SPI ports
+void SPI::begin(int bus, int frequency) {
+	mspi = new mraa::Spi(bus);
+
+	mspi->mode(mraa::SPI_MODE0);
+	mspi->bitPerWord(8);
+	mspi->frequency(frequency);
 }
 
 void SPI::end() {
-	delete mspi;
+	// Prophet: we should check for existence of mspi before deleting it
+	if (mspi != NULL)
+		delete mspi;
 }
 
 void SPI::setBitOrder(uint8_t bit_order) {
@@ -37,5 +48,6 @@ void SPI::chipSelect(int csn_pin){
 }
 
 SPI::~SPI() {
-
+	// Prophet: we should call end here to free used memory and unexport SPI interface
+	this->end();
 }

--- a/arch/MRAA/spi.h
+++ b/arch/MRAA/spi.h
@@ -22,8 +22,6 @@ public:
   inline void transfern(char* buf, uint32_t len);  
 
   void begin(void);
-  // Prophet: A customized SPI::begin can be used with parameters defined as macro in RF24_arch_config.h
-  void begin(int bus, int frequency);
   void end();
 
   void setBitOrder(uint8_t bit_order);

--- a/arch/MRAA/spi.h
+++ b/arch/MRAA/spi.h
@@ -21,7 +21,9 @@ public:
   inline void transfernb(char* tbuf, char* rbuf, uint32_t len);
   inline void transfern(char* buf, uint32_t len);  
 
-  void begin();
+  void begin(void);
+  // Prophet: A customized SPI::begin can be used with parameters defined as macro in RF24_arch_config.h
+  void begin(int bus, int frequency);
   void end();
 
   void setBitOrder(uint8_t bit_order);


### PR DESCRIPTION
I've made some updates to ```GPIO``` and ```SPI``` classes, so they destruct correctly. Also, an empty virtual destructor must be added to ```RF24``` so it will be called, and call destructors for all "full" members (eg not pointers).

I've tryed to add code that will set SPI parameters to ```RF24::csn```, but it resulted in heavy perfomance drop, due to MRAA constantly writing to syslog of incorrect SPI parameters, like changing 8MHz into 5MHz on my Galileo board.
I've added required defines into MRAA/RF24_arch_config.h so you can add ```|| defined(MRAA)``` in ```RF24::csn``` to test it yourself.

In RF24_config.h I've changed defined(MRAA) into defined(RF24_MRAA), as MRAA can only be defined in compile options, or in "arch/includes.h", also it's RF24_MRAA referred later in comments, so I assume it's correct.

Btw, I've tested all this code with RF24Network - looks good :)
