### PR TITLE
Fix operator precedence for isAckPayloadAvailable.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1376,7 +1376,7 @@ void RF24::writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
 
 bool RF24::isAckPayloadAvailable(void)
 {
-  return ! read_register(FIFO_STATUS) & _BV(RX_EMPTY);
+  return !(read_register(FIFO_STATUS) & _BV(RX_EMPTY));
 }
 
 /****************************************************************************/


### PR DESCRIPTION
In C, logical not (!) has precedence over bitwise and (&). The current code will yield the wrong result in the following case:

RX_EMPTY bit is unset, meaning packet is present.
Some other FIFO_STATUS bit is set, giving the register as a whole a non-zero value.
! non-zero value = 0
0 & _BV(RX_EMPTY) = 0

So even though a packet is present, false is returned. The correct implementation can be seen in the available() function.