### PR TITLE
Fixing one cause of "Failed, response timed out".

### DIFF
--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -27,6 +27,8 @@ void setup() {
   Serial.println(F("*** PRESS 'T' to begin transmitting to the other node"));
   
   radio.begin();
+  radio.setAutoAck(0);  // Disable autoACK (which is true by default). This example does not use it and it may be the cause of failure.
+  radio.setPayloadSize(sizeof(unsigned long)); // Here we are sending fixed payloads, and this was not set yet, nor we are yet using DPL feature.
 
   // Set the PA Level low to prevent power supply related issues since this is a
  // getting_started sketch, and the likelihood of close proximity of the devices. RF24_PA_MAX is default.


### PR DESCRIPTION
In my tests, i've seen this annoying message: "Now sending / Failed / Failed, response timed out".
I did connect every wire on the right place, and even used the 470uF capacitor to improve the supply, which proved necessary as the absence of it may cause several messages lost and failures.
After comparing this example with the pingpair_ack, and also searching inside the RF24 library, I've seen that this changes fiz this issue.
So, this is my contribution. I hope this may be useful for you too..