### PR TITLE
Do not use '\a' as a placeholder character

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -422,13 +422,13 @@ void RF24::print_observe_tx(uint8_t value)
 
 void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
 {
-  //char extra_tab = strlen_P(name) < 8 ? '\t' : '\a';
+  //char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
   //printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
   #if defined (RF24_LINUX)
     char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
     printf("%s\t%c =", name, extra_tab);
   #else
-    char extra_tab = strlen_P(name) < 8 ? '\t' : '\a';
+    char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
     printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
   #endif
   while (qty--)
@@ -445,7 +445,7 @@ void RF24::print_address_register(const char* name, uint8_t reg, uint8_t qty)
     char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
     printf("%s\t%c =",name,extra_tab);
   #else
-    char extra_tab = strlen_P(name) < 8 ? '\t' : '\a';
+    char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
     printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
   #endif
   while (qty--)


### PR DESCRIPTION
Using '\a' as a placeholder character is not a great idea because it triggers the bell sound in terminals that support it, which can get quite tiresome after a while. I think '\0' is the correct character in this instance because it has no visible (or audible) effect at all.

EDIT: I noticed you are using it on Linux already, so why not use it on Arduino too?