### PR TITLE
Add STM32F1 support

### DIFF
--- a/RF24_config.h
+++ b/RF24_config.h
@@ -20,7 +20,7 @@
   //#define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
   //#define SOFTSPI   // Requires library from https://github.com/greiman/DigitalIO
-  
+
   /**********************/
   #define rf24_max(a,b) (a>b?a:b)
   #define rf24_min(a,b) (a<b?a:b)
@@ -51,7 +51,13 @@
 //Teensy  
 #elif defined (TEENSYDUINO)
 
-  #include "arch/Teensy/RF24_arch_config.h"  
+  #include "arch/Teensy/RF24_arch_config.h"
+
+// STM32F1
+#elif defined (__STM32F1__)
+
+  #include "arch/STM32F1/RF24_arch_config.h"
+
 //Everything else
 #else 
 

--- a/arch/STM32F1/RF24_arch_config.h
+++ b/arch/STM32F1/RF24_arch_config.h
@@ -1,0 +1,21 @@
+  #if ARDUINO < 100
+	#include <WProgram.h>
+  #else
+	#include <Arduino.h>
+  #endif
+
+  #define _BV(x) (1<<(x))
+
+  #include <SPI.h>
+  #define _SPI SPI
+  extern SPIClass SPI;
+
+  #define printf_P(...)
+  #define printf(...)
+  
+  #ifdef SERIAL_DEBUG
+	#define IF_SERIAL_DEBUG(x) ({x;})
+  #else
+	#define IF_SERIAL_DEBUG(x)
+  #endif
+


### PR DESCRIPTION
This was tested with the STM32F1 arduino compatible core provided by this project: https://github.com/rogerclarkmelbourne/Arduino_STM32

The library compiles OK. All examples work on STM32F1, except for some minor problems in the sketches using avr specific stuff. 

I have tested the GettingStarted* sketches with the "STM32F103C8T6 ARM STM32 Minimum System Development Board Module For Arduino" you can find all over ebay.

