### PR TITLE
ATtiny2313/4313 support, ATtiny 3 pin mode fix

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1563,6 +1563,13 @@ void RF24::setRetries(uint8_t delay, uint8_t count)
 #	define DO   5   // PA5
 #	define USCK 6   // PA4
 #	define SS   3   // PA7
+#elif defined(__AVR_ATtiny2313__) || defined(__AVR_ATtiny4313__)
+// these depend on the core used (check pins_arduino.h)
+// tested with google-code core
+#	define DI   14  // PB5
+#	define DO   15  // PB6
+#	define USCK 16  // PB7
+#	define SS   13  // PB4
 #endif
 
 #if defined(RF24_TINY)

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1576,10 +1576,8 @@ void RF24::setRetries(uint8_t delay, uint8_t count)
 
 void SPIClass::begin() {
 
-  digitalWrite(SS, HIGH);
   pinMode(USCK, OUTPUT);
   pinMode(DO, OUTPUT);
-  pinMode(SS, OUTPUT);
   pinMode(DI, INPUT);
   USICR = _BV(USIWM0);
 

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -38,7 +38,7 @@
   #include "utility/includes.h"
 
 //ATTiny  
-#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__) || defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny2313__) || defined(__AVR_ATtiny4313__)
   
   #define RF24_TINY
   #include "utility/ATTiny/RF24_arch_config.h"


### PR DESCRIPTION
Added support for ATtiny2313 and ATtiny 4313 MCUs. Tested with google-code arduino-tiny core.

As for second change - slave select logic is implemented in main RF24 class with `csn()` function, using hardcoded SS pins in SPI class is not needed. Furthermore, calling `radio.begin()` will set SS pin OUTPUT and HIGH even in 3 pin mode, and it will overwrite any state set by user or another library configured to use this pin.