### PR TITLE
Support for ATXMega256D3

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -601,6 +601,12 @@ bool RF24::begin(void)
     pinMode(csn_pin,OUTPUT);
     _SPI.begin();
     csn(HIGH);
+  #elif defined(XMEGA_D3)
+	if (ce_pin != csn_pin) pinMode(ce_pin,OUTPUT);
+	_SPI.begin(csn_pin);
+	ce(LOW);
+	csn(HIGH);
+	delay(200);
   #else
     // Initialize pins
     if (ce_pin != csn_pin) pinMode(ce_pin,OUTPUT);  

--- a/RF24.h
+++ b/RF24.h
@@ -59,7 +59,7 @@ private:
   SPIUARTClass uspi;
 #endif
 
-#if defined (RF24_LINUX)
+#if defined (RF24_LINUX) || defined (XMEGA_D3) /* XMEGA can use SPI class */
   SPI spi;
 #endif
 #if defined (MRAA)
@@ -69,7 +69,7 @@ private:
   uint8_t ce_pin; /**< "Chip Enable" pin, activates the RX or TX role */
   uint8_t csn_pin; /**< SPI Chip select */
   uint16_t spi_speed; /**< SPI Bus Speed */
-#if defined (RF24_LINUX)
+#if defined (RF24_LINUX) || defined (XMEGA_D3)
   uint8_t spi_rxbuff[32+1] ; //SPI receive buffer (payload max 32 bytes)
   uint8_t spi_txbuff[32+1] ; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
 #endif  

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -15,7 +15,7 @@
 #define __RF24_CONFIG_H__
 
   /*** USER DEFINES:  ***/  
-  //#define FAILURE_HANDLING
+  #define FAILURE_HANDLING
   //#define SERIAL_DEBUG
   //#define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
@@ -43,6 +43,10 @@
   #define RF24_TINY
   #include "utility/ATTiny/RF24_arch_config.h"
 
+//ATXMega
+#elif defined(__AVR_ATxmega256D3__)
+  #define XMEGA_D3
+  #include "utility/ATXMegaD3/RF24_arch_config.h"
 //LittleWire  
 #elif defined(LITTLEWIRE)
   

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -15,7 +15,7 @@
 #define __RF24_CONFIG_H__
 
   /*** USER DEFINES:  ***/  
-  #define FAILURE_HANDLING
+  //#define FAILURE_HANDLING
   //#define SERIAL_DEBUG
   //#define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART

--- a/utility/ATXMegaD3/RF24_arch_config.h
+++ b/utility/ATXMegaD3/RF24_arch_config.h
@@ -1,0 +1,83 @@
+
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ */
+ 
+ /**
+ * @file RF24_arch_config.h
+ * General defines and includes for RF24/Linux
+ */
+
+ /**
+ * Example of RF24_arch_config.h for RF24 portability
+ *
+ * @defgroup Porting_General Porting: General
+ *
+ * 
+ * @{
+ */
+ 
+ 
+#ifndef __RF24_ARCH_CONFIG_H__
+#define __RF24_ARCH_CONFIG_H__
+
+#include <stddef.h>
+#include "spi.h"
+#include "gpio.h"
+#include "compatibility.h"
+#include <stdint.h>
+#include <stdio.h>
+//#include <time.h>
+#include <string.h>
+//#include <sys/time.h>
+
+//#define _BV(x) (1<<(x))
+#define _SPI spi
+
+#undef SERIAL_DEBUG
+#ifdef SERIAL_DEBUG
+#define IF_SERIAL_DEBUG(x) ({x;})
+#else
+#define IF_SERIAL_DEBUG(x)
+#endif
+
+// Avoid spurious warnings
+#if 1
+#if ! defined( NATIVE ) && defined( ARDUINO )
+#undef PROGMEM
+#define PROGMEM __attribute__(( section(".progmem.data") ))
+#undef PSTR
+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
+#endif
+#endif
+
+typedef uint16_t prog_uint16_t;
+#define PSTR(x) (x)
+#define printf_P printf
+#define strlen_P strlen
+#define PROGMEM
+#define pgm_read_word(p) (*(p)) 
+#define PRIPSTR "%s"
+#define pgm_read_byte(p) (*(p))
+
+// Function, constant map as a result of migrating from Arduino
+#define LOW GPIO::OUTPUT_LOW
+#define HIGH GPIO::OUTPUT_HIGH
+#define INPUT GPIO::DIRECTION_IN
+#define OUTPUT GPIO::DIRECTION_OUT
+#define digitalWrite(pin, value) GPIO::write(pin, value)
+#define pinMode(pin, direction) GPIO::open(pin, direction)
+#define delay(milisec) __msleep(milisec)
+#define delayMicroseconds(usec) __usleep(usec)
+#define millis() __millis()
+
+
+#endif // __RF24_ARCH_CONFIG_H__
+
+
+/*@}*/	

--- a/utility/ATXMegaD3/compatibility.c
+++ b/utility/ATXMegaD3/compatibility.c
@@ -1,0 +1,74 @@
+/*
+ * compatibility.c
+ *
+ * Created: 19/1/2016 15:31:35
+ *  Author: akatran
+ */ 
+
+#include <avr/io.h>
+#include <stdint.h>
+#include <util/delay.h>
+
+volatile uint32_t _millis;
+//volatile uint32_t _secsCounter;
+
+void __msleep(int milisec)
+{
+	while(milisec-- >0)
+	{
+		_delay_ms(1);
+	}
+}
+
+void __usleep(int usec)
+{
+	while(usec-- >0)
+	{
+		_delay_us(1);
+	}
+}
+
+
+void __start_timer()
+{
+	
+	// Timer details : Clock is 32MHz, Timer resolution is 8bit, Prescaler is 256, Period is 124, Real Time is 0.001s
+
+	/* Set the timer to run at the fastest rate. */
+	TCC0.CTRLA = TC_CLKSEL_DIV256_gc;
+
+	/* Configure the timer for normal counting. */
+	TCC0.CTRLB = TC_WGMODE_NORMAL_gc;
+
+	/* At 2 MHz, one tick is 0.5 us.  Set period to 8 us. */
+	TCC0.PER = 124;
+	//TCC0.PER = 2;
+
+	/* Configure timer to generate an interrupt on overflow. */
+	TCC0.INTCTRLA = TC_OVFINTLVL_HI_gc;
+
+	/* Enable this interrupt level. */
+	PMIC.CTRL = PMIC_LOLVLEN_bm | PMIC_MEDLVLEN_bm | PMIC_HILVLEN_bm;
+	
+	_millis=0;
+}
+
+long __millis()
+{
+	return _millis;
+}
+
+void update_milisec()
+{
+	_millis++;
+	//_secsCounter++;
+	//if (_secsCounter>=1000)
+	//{	
+		//_secsCounter =0;
+		//PORTF.OUTTGL = 128;
+	//}
+}
+
+
+
+

--- a/utility/ATXMegaD3/compatibility.h
+++ b/utility/ATXMegaD3/compatibility.h
@@ -1,0 +1,45 @@
+/* 
+ * File:   compatiblity.h
+ * Author: purinda
+ *
+ * Created on 24 June 2012, 3:08 PM
+ */
+
+ /**
+ * @file compatibility.h
+ * Class declaration for SPI helper files
+ */
+
+ /**
+ * Example of compatibility.h class declaration for timing functions portability
+ *
+ * @defgroup Porting_Timing Porting: Timing
+ *
+ * 
+ * @{
+ */
+ 
+#ifndef COMPATIBLITY_H
+#define	COMPATIBLITY_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+	
+#include <stddef.h>
+//#include <time.h>
+//#include <sys/time.h>
+
+void __msleep(int milisec);
+void __usleep(int usec);
+void __start_timer();
+long __millis();
+void update_milisec();
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* COMPATIBLITY_H */
+
+/*@}*/	

--- a/utility/ATXMegaD3/gpio.cpp
+++ b/utility/ATXMegaD3/gpio.cpp
@@ -1,0 +1,50 @@
+/*
+ * gpio.cpp
+ *
+ * Created: 20/1/2016 11:57:21
+ *  Author: akatran
+ */ 
+
+//#include "gpio_helper.h"
+#include "gpio.h"
+#include <stdlib.h>
+
+void GPIO::open(int port, int DDR)
+{
+	uint8_t pin;
+	PORT_t * p = GPIO_getPort(port,&pin);
+	if (DDR==0)
+	{
+		p->DIRCLR=pin;
+	}else if (DDR==1)
+	{
+		p->DIRSET = pin;	
+	}
+}
+
+void GPIO::close(int port)
+{
+	// Nothing to do with close;
+}
+
+int read(int port)
+{
+	uint8_t pin;
+	PORT_t * p = GPIO_getPort(port,&pin);
+	return p->IN;
+}
+
+void GPIO::write(int port,int value)
+{
+	uint8_t pin;
+	PORT_t * p = GPIO_getPort(port,&pin);
+	if (value==0)
+	{
+		p->OUTCLR=pin;
+	}else if (value==1)
+	{
+		p->OUTSET = pin;	
+	}
+	
+}
+

--- a/utility/ATXMegaD3/gpio.h
+++ b/utility/ATXMegaD3/gpio.h
@@ -1,0 +1,63 @@
+
+
+/**
+ * @file gpio.h
+ * Class declaration for SPI helper files
+ */
+
+ /**
+ * Example of gpio.h class declaration for GPIO portability
+ *
+ * @defgroup Porting_GPIO Porting: GPIO
+ *
+ * 
+ * @{
+ */
+#ifndef GPIO_H
+#define	GPIO_H
+
+#include <avr/io.h>
+#include "gpio_helper.h"
+
+
+class GPIO {
+public:
+ 	/* Constants */
+	static const int DIRECTION_OUT = 1;
+	static const int DIRECTION_IN = 0;
+	
+	static const int OUTPUT_HIGH = 1;
+	static const int OUTPUT_LOW = 0;
+		
+	GPIO();
+	
+	/**
+	 * Similar to Arduino pinMode(pin,mode);
+     * @param port
+     * @param DDR
+     */
+	static void open(int port, int DDR);
+	/**
+	 * 
+     * @param port
+     */
+	static void close(int port);
+	/**
+	 * Similar to Arduino digitalRead(pin);
+     * @param port
+     * @param value
+     */
+	static int read(int port);
+	/**
+	* Similar to Arduino digitalWrite(pin,state);
+	* @param port
+	* @param value
+	*/	
+	static void write(int port,int value);	
+	
+	virtual ~GPIO();
+
+};
+
+#endif	/* GPIO_H */
+/*@}*/	

--- a/utility/ATXMegaD3/gpio_helper.c
+++ b/utility/ATXMegaD3/gpio_helper.c
@@ -1,0 +1,45 @@
+/*
+ * gpio_helper.c
+ *
+ * Created: 22/1/2016 15:28:48
+ *  Author: akatran
+ */ 
+
+#include "gpio_helper.h"
+
+/**
+* Get the port corresponding in portnum. Default is PORTC.
+*/
+PORT_t * GPIO_getPort(int pinnum, uint8_t * pin_bm)
+//PORT_t * GPIO_getPort(int portnum)
+{
+	PORT_t * port = &PORTC;
+	if ( (pinnum >= XMEGA_PORTA_PIN0) && (pinnum<= XMEGA_PORTA_PIN7) )
+	{
+		port = &PORTA;
+		*pin_bm = (1<<pinnum);
+	}else if ( (pinnum >= XMEGA_PORTB_PIN0) && (pinnum<= XMEGA_PORTB_PIN7) )
+	{
+		port = &PORTB;
+		*pin_bm = (1<<(pinnum-8));
+	}else if ( (pinnum >= XMEGA_PORTC_PIN0) && (pinnum<= XMEGA_PORTC_PIN7) )
+	{
+		port = &PORTC;
+		*pin_bm = (1<<(pinnum-16));
+	}else if ( (pinnum >= XMEGA_PORTD_PIN0) && (pinnum<= XMEGA_PORTD_PIN7) )
+	{
+		port = &PORTD;
+		*pin_bm = (1<<(pinnum-24));
+	}else if ( (pinnum >= XMEGA_PORTE_PIN0) && (pinnum<= XMEGA_PORTE_PIN7) )
+	{
+		port = &PORTE;
+		*pin_bm = (1<<(pinnum-32));
+	}else if ( (pinnum >= XMEGA_PORTF_PIN0) && (pinnum<= XMEGA_PORTF_PIN7) )
+	{
+		port = &PORTF;
+		*pin_bm = (1<<(pinnum-40));
+	}
+
+	return port;
+
+}

--- a/utility/ATXMegaD3/gpio_helper.h
+++ b/utility/ATXMegaD3/gpio_helper.h
@@ -1,0 +1,89 @@
+/*
+ * gpio_helper.h
+ *
+ * Created: 22/1/2016 15:29:12
+ *  Author: akatran
+ */ 
+
+
+#ifndef GPIO_HELPER_H_
+#define GPIO_HELPER_H_
+
+#include <avr/io.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/* Defines */
+
+
+#define XMEGA_PORTA_PIN0   0
+#define XMEGA_PORTA_PIN1   1
+#define XMEGA_PORTA_PIN2   2
+#define XMEGA_PORTA_PIN3   3
+#define XMEGA_PORTA_PIN4   4
+#define XMEGA_PORTA_PIN5   5
+#define XMEGA_PORTA_PIN6   6
+#define XMEGA_PORTA_PIN7   7
+
+#define XMEGA_PORTB_PIN0   8
+#define XMEGA_PORTB_PIN1   9
+#define XMEGA_PORTB_PIN2  10
+#define XMEGA_PORTB_PIN3  11
+#define XMEGA_PORTB_PIN4  12
+#define XMEGA_PORTB_PIN5  13
+#define XMEGA_PORTB_PIN6  14
+#define XMEGA_PORTB_PIN7  15
+
+#define XMEGA_PORTC_PIN0  16
+#define XMEGA_PORTC_PIN1  17
+#define XMEGA_PORTC_PIN2  18
+#define XMEGA_PORTC_PIN3  19
+#define XMEGA_PORTC_PIN4  20
+#define XMEGA_PORTC_PIN5  21
+#define XMEGA_PORTC_PIN6  22
+#define XMEGA_PORTC_PIN7  23
+
+#define XMEGA_PORTD_PIN0  24
+#define XMEGA_PORTD_PIN1  25
+#define XMEGA_PORTD_PIN2  26
+#define XMEGA_PORTD_PIN3  27
+#define XMEGA_PORTD_PIN4  28
+#define XMEGA_PORTD_PIN5  29
+#define XMEGA_PORTD_PIN6  30
+#define XMEGA_PORTD_PIN7  31
+
+#define XMEGA_PORTE_PIN0  32
+#define XMEGA_PORTE_PIN1  33
+#define XMEGA_PORTE_PIN2  34
+#define XMEGA_PORTE_PIN3  35
+#define XMEGA_PORTE_PIN4  36
+#define XMEGA_PORTE_PIN5  37
+#define XMEGA_PORTE_PIN6  38
+#define XMEGA_PORTE_PIN7  39
+
+#define XMEGA_PORTF_PIN0  40
+#define XMEGA_PORTF_PIN1  41
+#define XMEGA_PORTF_PIN2  42
+#define XMEGA_PORTF_PIN3  43
+#define XMEGA_PORTF_PIN4  44
+#define XMEGA_PORTF_PIN5  45
+#define XMEGA_PORTF_PIN6  46
+#define XMEGA_PORTF_PIN7  47
+
+
+
+#define XMEGA_SPI_PORT_C 20
+#define XMEGA_SPI_PORT_D 28
+
+
+//void GPIO_getPort(int pinnum, PORT_t * port, uint8_t pin);
+//void GPIO_getPort(int pinnum, PORT_t * port, uint8_t * pin_bm);
+PORT_t * GPIO_getPort(int pinnum, uint8_t * pin_bm);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif /* GPIO_HELPER_H_ */

--- a/utility/ATXMegaD3/includes.h
+++ b/utility/ATXMegaD3/includes.h
@@ -1,0 +1,31 @@
+
+ /**
+ * @file includes.h
+ * Configuration defines for RF24/Linux
+ */
+
+ /**
+ * Example of includes.h for RF24 Linux portability
+ *
+ * @defgroup Porting_Includes Porting: Includes
+ *
+ * 
+ * @{
+ */
+  
+#ifndef __RF24_INCLUDES_H__
+#define __RF24_INCLUDES_H__
+
+  /**
+   * Define a specific platform for this configuration
+   */
+ // #define RF24_BBB
+  
+  /**
+   * Load the correct configuration for this platform
+  */
+  //#include "BBB/RF24_arch_config.h"
+  
+#endif
+
+/*@}*/	

--- a/utility/ATXMegaD3/spi.cpp
+++ b/utility/ATXMegaD3/spi.cpp
@@ -1,0 +1,64 @@
+/*
+ * spi.cpp
+ *
+ * Created: 20/1/2016 10:10:39
+ *  Author: akatran
+ */ 
+
+#include <avr/io.h>
+#include "gpio_helper.h"
+#include "spi.h"
+
+using namespace std;
+
+void SPI::begin(uint8_t _port)
+{
+	if (_port==XMEGA_SPI_PORT_C) // Select SPI on PORTC
+	{
+		device = &SPIC;
+		port = &PORTC;
+	}else if (_port==XMEGA_SPI_PORT_D) // Select SPI on PORTD
+	{
+		device = &SPID;
+		port = &PORTD;
+	}
+	
+	init();
+}
+
+uint8_t SPI::transfer(uint8_t tx_)
+{
+	register8_t data;
+	device->DATA = tx_;
+	while(!(device->STATUS & (1<<7)));
+	data = device->DATA;
+	//PORTF.OUT = data;
+	return data;
+}
+
+void SPI::init()
+{
+	port->DIRCLR = SPI_MISO_bm;
+	port->DIRSET = SPI_MOSI_bm | SPI_SCK_bm | SPI_SS_bm;
+	
+	//device->CTRL = 0;
+	device->CTRL = SPI_ENABLE_bm | SPI_MASTER_bm | SPI_MODE_0_gc | SPI_PRESCALER_DIV4_gc;
+	device->INTCTRL =0; //Disable interrupts
+
+}
+
+
+SPI::SPI()
+{
+	
+}
+
+SPI::~SPI()
+{
+ 	
+}
+
+void operator delete(void * p) // or delete(void *, std::size_t)
+{
+
+}

--- a/utility/ATXMegaD3/spi.h
+++ b/utility/ATXMegaD3/spi.h
@@ -1,0 +1,90 @@
+
+/**
+ * @file spi.h
+ * Class declaration for SPI helper files
+ */
+
+ /**
+ * Example of spi.h class declaration for SPI portability
+ *
+ * @defgroup Porting_SPI Porting: SPI
+ *
+ * 
+ * @{
+ */
+
+#ifndef __XMEGASPI_H__
+#define __XMEGASPI_H__
+
+#include <avr/io.h>
+#include <stdint.h>
+//#include <string.h>
+//#include <unistd.h>
+//#include <stdio.h>
+//#include <stdlib.h>
+//#include <getopt.h>
+//#include <fcntl.h>
+//#include <sys/ioctl.h>
+//#include <inttypes.h>
+//#include <linux/types.h>
+//#include <linux/spi/spidev.h> 
+
+#define SPI_SS_bm (1<<4) /* SPI SS pin mask 4 */
+#define SPI_MOSI_bm (1<<5) /* SPI MOSI pin mask 5 */
+#define SPI_MISO_bm (1<<6) /* SPI MISO pin mask 6 */
+#define SPI_SCK_bm (1<<7) /* SPI SCK pin mask 7 */
+
+using namespace std;
+
+
+
+class SPI {
+public:
+
+	/**
+	* SPI constructor
+	*/	 
+	SPI();
+	
+	/**
+	* Start SPI
+	* @param port is the SPI port (XMEGA_SPI_PORT_C for SPI on PORTC, XMEGA_SPI_PORT_D on PORTD etc).
+	*/
+	void begin(uint8_t port);
+	/**
+	* Transfer a single byte
+	* @param tx_ Byte to send
+	* @return Data returned via spi
+	*/
+	uint8_t transfer(uint8_t tx_);
+	
+	/**
+	* Transfer a buffer of data
+	* @param tbuf Transmit buffer
+	* @param rbuf Receive buffer
+	* @param len Length of the data
+	*/
+	void transfernb(char* tbuf, char* rbuf, uint32_t len);
+
+	/**
+	* Transfer a buffer of data without an rx buffer
+	* @param buf Pointer to a buffer of data
+	* @param len Length of the data
+	*/	
+	void transfern(char* buf, uint32_t len);
+	
+	virtual ~SPI();
+
+private:
+    
+	/** Default SPI device */
+	SPI_t * device;
+	/* Port of the SPI */
+	PORT_t * port;
+
+	void init();	
+};
+
+#endif /*__XMEGASPI_H__*/
+
+/*@}*/


### PR DESCRIPTION
The RF24 library can now be included into a Atmel Studio Solution and
get compiled as part of the solution.
Currently only XMEGA256D3 is supported.