### PR TITLE
maskIRQ: Fixed function to clear interrupt bits first.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1016,7 +1016,12 @@ bool RF24::txStandBy(uint32_t timeout, bool startTx){
 
 void RF24::maskIRQ(bool tx, bool fail, bool rx){
 
-	write_register(CONFIG, ( read_register(CONFIG) ) | fail << MASK_MAX_RT | tx << MASK_TX_DS | rx << MASK_RX_DR  );
+	uint8_t config = read_register(CONFIG);
+	/* clear the interrupt flags */
+	config &= ~(1 << MASK_MAX_RT | 1 << MASK_TX_DS | 1 << MASK_RX_DR);
+	/* set the specified interrupt flags */
+	config |= fail << MASK_MAX_RT | tx << MASK_TX_DS | rx << MASK_RX_DR;
+	write_register(CONFIG, config);
 }
 
 /****************************************************************************/


### PR DESCRIPTION
maskIRQ was buggy. The interrupts bits were only being ORed. They need to be AND cleared first.