### PR TITLE
Fix warning: C++11 requires a space between literal and identifier

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -556,10 +556,10 @@ void RF24::printDetails(void)
   print_byte_register(PSTR("CONFIG\t"),CONFIG);
   print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
 
-  printf_P(PSTR("Data Rate\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
-  printf_P(PSTR("Model\t\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
-  printf_P(PSTR("CRC Length\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
-  printf_P(PSTR("PA Power\t = "PRIPSTR"\r\n"),  pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+  printf_P(PSTR("Data Rate\t = " PRIPSTR "\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
+  printf_P(PSTR("Model\t\t = " PRIPSTR "\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
+  printf_P(PSTR("CRC Length\t = " PRIPSTR "\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
+  printf_P(PSTR("PA Power\t = " PRIPSTR "\r\n"),  pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
 
 }
 


### PR DESCRIPTION
This change fixes the following compiler warning I get when building
on Arduino IDE version 1.6.7

"/var/folders/sv/27zk61c9449f9wycpfhq9dmr0000gn/T/build68a338274e8c0af55d2a1e6113ec3df2.tmp/libraries/RF24/RF24.cpp.o"
/Users/flaviof/Documents/Arduino/libraries/RF24/RF24.cpp:559:17: warning: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wliteral-suffix]
   printf_P(PSTR("Data Rate\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
                 ^
/Users/flaviof/Documents/Arduino/libraries/RF24/RF24.cpp:560:17: warning: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wliteral-suffix]
   printf_P(PSTR("Model\t\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
                 ^
/Users/flaviof/Documents/Arduino/libraries/RF24/RF24.cpp:561:17: warning: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wliteral-suffix]
   printf_P(PSTR("CRC Length\t = "PRIPSTR"\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
                 ^
/Users/flaviof/Documents/Arduino/libraries/RF24/RF24.cpp:562:17: warning: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wliteral-suffix]
   printf_P(PSTR("PA Power\t = "PRIPSTR"\r\n"),  pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
                 ^