### PR TITLE
Changes in RF24_config.h prohibits the detection of XMEGA.

### DIFF
--- a/RF24.h
+++ b/RF24.h
@@ -1847,7 +1847,7 @@ private:
  * 
  * The RF24 driver can be build as a static library with Atmel Studio 7 in order to be included as any other library in another program for the XMEGA family.
  *
- * Currently only the </b>ATXMEGA256D3</b> is implemented.
+ * Currently only the </b>ATXMEGA D3</b> family is implemented.
  * 
  * @section Preparation 
  * 
@@ -1856,7 +1856,7 @@ private:
  * 
  * @code
  * utility\
- *   ATXMega256D3\
+ *   ATXMegaD3\
  *     compatibility.c
  *     compatibility.h
  *     gpio.cpp

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -28,9 +28,10 @@
   #if defined SPI_HAS_TRANSACTION && !defined SPI_UART && !defined SOFTSPI
     #define RF24_SPI_TRANSACTIONS
   #endif
-  
+ 
+ 
 //ATXMega
-#if defined(__AVR_ATxmega256D3__) // In order to be available both in windows and linux this should take presence here.
+#if defined(__AVR_ATxmega64D3__) || defined(__AVR_ATxmega128D3__) || defined(__AVR_ATxmega192D3__) || defined(__AVR_ATxmega256D3__) || defined(__AVR_ATxmega384D3__) // In order to be available both in windows and linux this should take presence here.
   #define XMEGA
   #define XMEGA_D3
   #include "utility/ATXMegaD3/RF24_arch_config.h"

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -29,7 +29,12 @@
     #define RF24_SPI_TRANSACTIONS
   #endif
   
-#if ( !defined (ARDUINO) ) // Any non-arduino device is handled via configure/Makefile
+//ATXMega
+#if defined(__AVR_ATxmega256D3__) // In order to be available both in windows and linux this should take presence here.
+  #define XMEGA
+  #define XMEGA_D3
+  #include "utility/ATXMegaD3/RF24_arch_config.h"
+#elif ( !defined (ARDUINO) ) // Any non-arduino device is handled via configure/Makefile
 
   // The configure script detects device and copies the correct includes.h file to /utility/includes.h
   // This behavior can be overridden by calling configure with respective parameters
@@ -41,11 +46,7 @@
   #define RF24_TINY
   #include "utility/ATTiny/RF24_arch_config.h"
 
-//ATXMega
-#elif defined(__AVR_ATxmega256D3__)
-  #define XMEGA
-  #define XMEGA_D3
-  #include "utility/ATXMegaD3/RF24_arch_config.h"
+
 //LittleWire  
 #elif defined(LITTLEWIRE)
   


### PR DESCRIPTION
I have change the detection scheme in order to correctly detect the Atmel Studio 7 ATXMega256D3 MCU.

Because in windows would take extra steps to use the configure in order to put the correct include.h files, I change the order of detecting the MCU.

The other way is to put the needed changes in configure file and call it from windows command prompt (and in linux too) before any other action meaning that users have to install additional software.  