### PR TITLE
Change examples_RPi to examples_linux

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -897,7 +897,7 @@ EXCLUDE_SYMBOLS        =
 # command).
 
 EXAMPLE_PATH           = examples \
-                         examples_RPi
+                         examples_linux
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/RF24.h
+++ b/RF24.h
@@ -1579,7 +1579,7 @@ private:
  * @code ./install.sh @endcode
  * 4. Run an example from one of the libraries
  * @code 
- * cd rf24libs/RF24/examples_RPi  
+ * cd rf24libs/RF24/examples_linux  
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
  * @code nano gettingstarted.cpp
@@ -1602,7 +1602,7 @@ private:
  * **Note:** See the <a href="http://iotdk.intel.com/docs/master/mraa/index.html">MRAA </a> documentation for more info on installing MRAA
  *    @code sudo make install  OR  sudo make install RF24_MRAA=1 @endcode
  * @code
- * cd examples_RPi  
+ * cd examples_linux  
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
  * @code nano gettingstarted.cpp 
@@ -1639,7 +1639,7 @@ private:
  *    @code sudo make install -B RF24_MRAA=1 @endcode
  * 5. Configure the correct pins in gettingstarted.cpp (See http://iotdk.intel.com/docs/master/mraa/index.html )
  *    @code
- *    cd examples_RPi  
+ *    cd examples_linux  
  *    nano gettingstarted.cpp 
  *    @endcode
  * 6. Build an example
@@ -1679,7 +1679,7 @@ private:
  * @code ./install.sh @endcode
  * 4. Run an example from one of the libraries
  * @code 
- * cd rf24libs/RF24/examples_RPi  
+ * cd rf24libs/RF24/examples_linux  
  * make  
  * sudo ./gettingstarted  
  * @endcode
@@ -1696,7 +1696,7 @@ private:
  *    @code cd RF24 @endcode
  * 4. Build the library, and run an example file: 
  * @code sudo make install
- * cd examples_RPi  
+ * cd examples_linux  
  * make  
  * sudo ./gettingstarted
  * @endcode


### PR DESCRIPTION
When trying to follow the documentation I noticed that the old folder names were being used.