### PR TITLE
Fix clamping to a single hex digit

### DIFF
--- a/examples/scanner/scanner.ino
+++ b/examples/scanner/scanner.ino
@@ -118,7 +118,7 @@ void loop(void)
   int i = 0;
   while ( i < num_channels )
   {
-    printf("%x",min(0xf,values[i]&0xf));
+    printf("%x",min(0xf,values[i]));
     ++i;
   }
   Serial.println();


### PR DESCRIPTION
The desired functionality is to display all channel measurements greater than 0xF as 0xF. The current behavior picks the minimum between `0xF` and `(value & 0xF)`, which is just the last hex digit of the measurement.

If the value was `0x12`, the code would print `2` rather than `F`. This change just makes `min` compare `0xF` with the full value of the measurement, such that measurements above `0xF` will always get clamped correctly.