### PR TITLE
fix SPIDEV interface

### DIFF
--- a/utility/SPIDEV/spi.cpp
+++ b/utility/SPIDEV/spi.cpp
@@ -1,46 +1,42 @@
-/* 
+/*
  * File:   spi.cpp
  * Author: Purinda Gunasekara <purinda@gmail.com>
- * 
+ *
  * Created on 24 June 2012, 11:00 AM
- * 
+ *
  * Inspired from spidev test in linux kernel documentation
- * www.kernel.org/doc/Documentation/spi/spidev_test.c 
+ * www.kernel.org/doc/Documentation/spi/spidev_test.c
  */
 
 #include "spi.h"
 
+#include <fcntl.h>
+#include <linux/spi/spidev.h>
 #include <memory.h>
-#include <pthread.h>
-static pthread_mutex_t spiMutex;
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define RF24_SPIDEV_BITS 8
 
 SPI::SPI():fd(-1) {
 }
 
 void SPI::begin(int busNo){
 
-	this->device = "/dev/spidev0.0";
     /* set spidev accordingly to busNo like:
      * busNo = 23 -> /dev/spidev2.3
      *
      * a bit messy but simple
      * */
-    this->device[11] += (busNo / 10) % 10;
-    this->device[13] += busNo % 10;
-	this->bits = 8;
-	this->speed = RF24_SPIDEV_SPEED;
-	this->mode=0;
-    //this->mode |= SPI_NO_CS;
-	this->init();
-}
+	char device[] = "/dev/spidev0.0";
+	device[11] += (busNo / 10) % 10;
+	device[13] += busNo % 10;
 
-void SPI::init()
-{
-	int ret;
-    
     if (this->fd < 0)  // check whether spi is already open
     {
-	  this->fd = open(this->device.c_str(), O_RDWR);
+	  this->fd = open(device, O_RDWR);
 
       if (this->fd < 0)
       {
@@ -49,117 +45,113 @@ void SPI::init()
       }
     }
 
+	init();
+}
+
+void SPI::init()
+{
+	uint8_t bits = RF24_SPIDEV_BITS;
+	uint32_t speed = RF24_SPIDEV_SPEED;
+	uint8_t mode = 0;
+
+	int ret;
 	/*
 	 * spi mode
 	 */
-	ret = ioctl(this->fd, SPI_IOC_WR_MODE, &this->mode);
+	ret = ioctl(this->fd, SPI_IOC_WR_MODE, &mode);
 	if (ret == -1)
 	{
 		perror("can't set spi mode");
-		abort();		
+		abort();
 	}
 
-	ret = ioctl(this->fd, SPI_IOC_RD_MODE, &this->mode);
+	ret = ioctl(this->fd, SPI_IOC_RD_MODE, &mode);
 	if (ret == -1)
 	{
 		perror("can't set spi mode");
-		abort();				
+		abort();
 	}
-	
+
 	/*
 	 * bits per word
 	 */
-	ret = ioctl(this->fd, SPI_IOC_WR_BITS_PER_WORD, &this->bits);
+	ret = ioctl(this->fd, SPI_IOC_WR_BITS_PER_WORD, &bits);
 	if (ret == -1)
 	{
 		perror("can't set bits per word");
-		abort();				
+		abort();
 	}
 
-	ret = ioctl(this->fd, SPI_IOC_RD_BITS_PER_WORD, &this->bits);
+	ret = ioctl(this->fd, SPI_IOC_RD_BITS_PER_WORD, &bits);
 	if (ret == -1)
 	{
 		perror("can't set bits per word");
-		abort();						
+		abort();
 	}
 	/*
 	 * max speed hz
 	 */
-	ret = ioctl(this->fd, SPI_IOC_WR_MAX_SPEED_HZ, &this->speed);
+	ret = ioctl(this->fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
 	if (ret == -1)
 	{
 		perror("can't set max speed hz");
-		abort();						
+		abort();
 	}
 
-	ret = ioctl(this->fd, SPI_IOC_RD_MAX_SPEED_HZ, &this->speed);
+	ret = ioctl(this->fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed);
 	if (ret == -1)
 	{
 		perror("can't set max speed hz");
-		abort();						
+		abort();
 	}
 }
 
 uint8_t SPI::transfer(uint8_t tx)
 {
-    pthread_mutex_lock (&spiMutex);
-
-    struct spi_ioc_transfer tr;
-    memset(&tr, 0, sizeof(tr));
-    tr.tx_buf = (unsigned long)&tx;
-    tr.rx_buf = (unsigned long)&tx;
-    tr.len = sizeof(tx);
-    tr.speed_hz = this->speed;
-    tr.delay_usecs = 0;
-    tr.bits_per_word = this->bits;
-    tr.cs_change = 0;
+	struct spi_ioc_transfer tr;
+	memset(&tr, 0, sizeof(tr));
+	tr.tx_buf = (unsigned long)&tx;
+	uint8_t rx;
+	tr.rx_buf = (unsigned long)&rx;
+	tr.len = sizeof(tx);
+	tr.speed_hz = RF24_SPIDEV_SPEED;
+	tr.delay_usecs = 0;
+	tr.bits_per_word = RF24_SPIDEV_BITS;
+	tr.cs_change = 0;
 
 	int ret;
 	ret = ioctl(this->fd, SPI_IOC_MESSAGE(1), &tr);
 	if (ret < 1)
 	{
-        pthread_mutex_unlock (&spiMutex);
 		perror("can't send spi message");
-		abort();		
+		abort();
 	}
 
-    pthread_mutex_unlock (&spiMutex);
-	return tx;
+	return rx;
 }
 
 void SPI::transfernb(char* tbuf, char* rbuf, uint32_t len)
 {
-	pthread_mutex_lock (&spiMutex);
-
     struct spi_ioc_transfer tr;
     memset(&tr, 0, sizeof(tr));
     tr.tx_buf = (unsigned long)tbuf;
     tr.rx_buf = (unsigned long)rbuf;
     tr.len = len;
-    tr.speed_hz = this->speed;
+    tr.speed_hz = RF24_SPIDEV_SPEED;
     tr.delay_usecs = 0;
-    tr.bits_per_word = this->bits;
+    tr.bits_per_word = RF24_SPIDEV_BITS;
     tr.cs_change = 0;
 
 	int ret;
 	ret = ioctl(this->fd, SPI_IOC_MESSAGE(1), &tr);
 	if (ret < 1)
 	{
-        pthread_mutex_unlock (&spiMutex);
 		perror("can't send spi message");
-		abort();		
+		abort();
 	}
-    pthread_mutex_unlock (&spiMutex);
 }
-
-void SPI::transfern(char* buf, uint32_t len)
-{
-    transfernb(buf, buf, len);
-}
-
 
 SPI::~SPI() {
-    if (!(this->fd < 0))
-	    close(this->fd);
+	if (!(this->fd < 0))
+		close(this->fd);
 }
-

--- a/utility/SPIDEV/spi.h
+++ b/utility/SPIDEV/spi.h
@@ -40,10 +40,6 @@
 #define RF24_SPIDEV_SPEED 8000000
 #endif
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
-using namespace std;
-
 class SPI {
 public:
 	
@@ -59,10 +55,10 @@ public:
 	
 	/**
 	* Transfer a single byte
-	* @param tx_ Byte to send
+	* @param tx Byte to send
 	* @return Data returned via spi
 	*/
-	uint8_t transfer(uint8_t tx_);
+	uint8_t transfer(uint8_t tx);
 	
 	/**
 	* Transfer a buffer of data
@@ -84,7 +80,7 @@ public:
 private:
 
 	/** Default SPI device */
-	string device;
+    std::string device;
 	/** SPI Mode set */
 	uint8_t mode;
 	/** word size*/

--- a/utility/SPIDEV/spi.h
+++ b/utility/SPIDEV/spi.h
@@ -1,7 +1,7 @@
-/* 
+/*
  * File:   spi.h
  * Author: Purinda Gunasekara <purinda@gmail.com>
- * 
+ *
  * Created on 24 June 2012, 11:00 AM
  */
 
@@ -13,7 +13,7 @@
  * \cond HIDDEN_SYMBOLS
  * Class declaration for SPI helper files
  */
- 
+
  /**
  * Example GPIO.h file
  *
@@ -22,18 +22,8 @@
  * See RF24_arch_config.h for additional information
  * @{
  */
- 
-#include <string>
-#include <stdint.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <getopt.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
+
 #include <inttypes.h>
-#include <linux/types.h>
-#include <linux/spi/spidev.h>
 
 #ifndef RF24_SPIDEV_SPEED
 /* 8MHz as default */
@@ -42,24 +32,24 @@
 
 class SPI {
 public:
-	
+
 	/**
 	* SPI constructor
-	*/	 
+	*/
 	SPI();
-	
+
 	/**
 	* Start SPI
 	*/
 	void begin(int busNo);
-	
+
 	/**
 	* Transfer a single byte
 	* @param tx Byte to send
 	* @return Data returned via spi
 	*/
 	uint8_t transfer(uint8_t tx);
-	
+
 	/**
 	* Transfer a buffer of data
 	* @param tbuf Transmit buffer
@@ -72,24 +62,18 @@ public:
 	* Transfer a buffer of data without an rx buffer
 	* @param buf Pointer to a buffer of data
 	* @param len Length of the data
-	*/	
-	void transfern(char* buf, uint32_t len);
-	
-	virtual ~SPI();
+	*/
+	void transfern(char* buf, uint32_t len) {
+	  transfernb(buf, buf, len);
+	}
+
+	~SPI();
 
 private:
 
-	/** Default SPI device */
-    std::string device;
-	/** SPI Mode set */
-	uint8_t mode;
-	/** word size*/
-	uint8_t bits;
-	/** Set SPI speed*/
-	uint32_t speed;
 	int fd;
 
-	void init();	
+	void init();
 };
 
 /**


### PR DESCRIPTION
fix several errors:
struct spi_ioc_transfer tr; was not initialized to zero.
initializer did not set the proper members.
cs_change = 0 causes incorrect csn behaviour.
using namespace std; can cause name conflicts in client code.
