### PR TITLE
 added disableDynamicPayloads()

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1255,6 +1255,26 @@ void RF24::enableDynamicPayloads(void)
 }
 
 /****************************************************************************/
+void RF24::disableDynamicPayloads(void)
+{
+  // Disables dynamic payload throughout the system.  Also disables Ack Payloads
+
+    //toggle_features();
+    write_register(FEATURE,read_register(FEATURE) & ~(_BV(EN_DPL) | _BV(EN_ACK_PAY)));
+
+
+  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
+
+  // Disable dynamic payload on all pipes
+  //
+  // Not sure the use case of only having dynamic payload on certain
+  // pipes, so the library does not support it.
+  write_register(DYNPD,read_register(DYNPD) & ~( _BV(DPL_P5) | _BV(DPL_P4) | _BV(DPL_P3) | _BV(DPL_P2) | _BV(DPL_P1) | _BV(DPL_P0)));
+
+  dynamic_payloads_enabled = false;
+}
+
+/****************************************************************************/
 
 void RF24::enableAckPayload(void)
 {

--- a/RF24.h
+++ b/RF24.h
@@ -782,6 +782,15 @@ s   *
   void enableDynamicPayloads(void);
   
   /**
+   * Disable dynamically-sized payloads
+   *
+   * This disables dynamic payloads on ALL pipes. Since Ack Payloads
+   * requires Dynamic Payloads, Ack Payloads are also disabled.
+   *
+   */
+  void disableDynamicPayloads(void);
+  
+  /**
    * Enable dynamic ACKs (single write multicast or unicast) for chosen messages
    *
    * @note To enable full multicast or per-pipe multicast, use setAutoAck()


### PR DESCRIPTION
Ack payloads are also disabled at the same time because they depend on
dynamic payloads.

This is needed because I have an old protocol where the TX and RX use fixed length, and want the new code using dynamic lengths to be backwards compatible with the old receivers.