### PR TITLE
RF24::begin: reset dynamic_payloads_enabled to false

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -667,6 +667,7 @@ bool RF24::begin(void)
   toggle_features();
   write_register(FEATURE,0 );
   write_register(DYNPD,0);
+  dynamic_payloads_enabled = false;
 
   // Reset current status
   // Notice reset and flush is the last thing we do


### PR DESCRIPTION
Hi,

I'm using this library for automated benchmarks and energy measurements, which means that I frequently call begin() to re-set the nRF24 chip to its defaults and start a new measurement with different parameters. I noticed that begin() initializes the hardware with dynamic payloads disabled, but does not set the corresponding variable, which means that it can remain true if dynamic payloads were previously enabled (even though the call to begin() disables them).

Calling begin() more than once probably isn't the inteded usage, but just in case someone else also does this, this commit should help them.